### PR TITLE
Reword "compiler documentation" to "language documentation"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -31,7 +31,7 @@ title: Home
 <h2>Resources</h2>
 
 <ul>
-  <li><a href="http://docs.purescript.org/">Compiler Documentation</a></li>
+  <li><a href="http://docs.purescript.org/">Language Documentation</a></li>
   <li><a href="irc://irc.freenode.com/#purescript">#purescript IRC @ FreeNode</a></li>
   <li><a href="http://twitter.com/purescript">Twitter</a></li>
   <li><a href="http://try.purescript.org/">Try PureScript!</a></li>


### PR DESCRIPTION
The provided link is to the documentation of the language, not any one compiler
