### PR TITLE
Add package manager section to Download page

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -40,6 +40,22 @@
     </section>
 
     <section>
+      <h2>Package managers</h2>
+      <p>OS X via <a href="http://brew.sh/">Homebrew</a></p>
+      <div class="codeblock">
+<pre>
+brew install purescript
+</pre>
+      </div>
+      <p>Arch Linux via <a href="https://aur.archlinux.org/packages/purescript-bin/">AUR</a></p>
+      <div class="codeblock">
+<pre>
+yaourt -S purescript-bin
+</pre>
+      </div>
+    </section>
+
+    <section>
 
       <h2>Cabal</h2>
 


### PR DESCRIPTION
I only found commands for two, but others can be added later. In particular, a Chocolatey package for Windows would be nice.
