### PR TITLE
Add installation instruction via npm

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -59,6 +59,12 @@ yaourt -S purescript-bin
 choco install purescript
 </pre>
       </div>
+      <p>Every platform via <a href="https://www.npmjs.com/">npm</a></p>
+      <div class="codeblock">
+<pre>
+npm install -g purescript
+</pre>
+      </div>
     </section>
 
     <section>


### PR DESCRIPTION
Now we can install PureScript via [npm](https://www.npmjs.com/) since I created [`purescript`](https://www.npmjs.com/package/purescript) npm package.

```sh
$ npm install -g purescript

$ psc --help
$ psc-docs --help
$ psc-make --help
$ psci --help
```
