### PR TITLE
Adds some stub instructions for working on the Purescript site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
 purescript.github.io
 ====================
 
-Project Homepage
+The Purescript project homepage.
+
+
+## Development
+
+TODO: Describe how the Pandoc Markdown => HTML process works.
+
+You'll need [npm](https://www.npmjs.org) and [Compass](http://compass-style.org/install/) installed to proceed. Run:
+
+    npm install
+    grunt
+
+To have a server running to preview changes, kick off:
+
+    grunt dev
+
+... And open your browser to [http://0.0.0.0:8000](http://0.0.0.0:8000).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-compass": "^1.0.1",
     "grunt-contrib-connect": "^0.8.0",


### PR DESCRIPTION
* Adds the beginning of some development instructions. Missing some expanded notes on how Pandoc figures into all of this.
* Adds `grunt-cli` for seamless global-vs-local install workflows. (Some people don't have Grunt installed globally already, and are used to always-local installations of binaries; adding `grunt-cli` like this should work for both kinds of installations.)