### PR TITLE
Remove references to pulp dep

### DIFF
--- a/learn/eff/index.markdown
+++ b/learn/eff/index.markdown
@@ -39,7 +39,7 @@ printRandom = do
 This example requires the `purescript-console` and `purescript-random` dependencies to be installed:
 
     pulp init
-    pulp dep i purescript-console purescript-random
+    bower install --save purescript-console purescript-random
 
 If you save this file as `RandomExample.purs`, you will be able to compile and run it using PSCi:
 

--- a/learn/getting-started/index.markdown
+++ b/learn/getting-started/index.markdown
@@ -18,9 +18,9 @@ The Purescript compiler (psc) can be installed with npm:
 
 PureScript's core libraries are configured to use the [Pulp](https://github.com/bodil/pulp) build tool, and packages are available in the [Bower registry](http://bower.io/search/?q=purescript-).
 
-If you don't have Pulp installed, install it now:
+If you don't have Pulp and Bower installed, install them now:
 
-    npm install -g pulp
+    npm install -g pulp bower
 
 Create a new project in an empty directory using `pulp init`:
 
@@ -49,13 +49,9 @@ If everything was built successfully, and the tests ran without problems, then t
 
 #### Installing Dependencies
 
-Dependencies can be installed using Bower, if you have it installed globally:
+Dependencies can be installed using Bower:
 
     bower install purescript-lists --save
-
-If you want to use Pulp, you can run `pulp dep`:
-
-    pulp dep install purescript-lists --save
 
 #### Working in PSCI
 

--- a/learn/quickcheck/index.markdown
+++ b/learn/quickcheck/index.markdown
@@ -15,7 +15,7 @@ Create a new project using Pulp, install `purescript-quickcheck`, and open PSCi:
 
 ```text
 pulp init
-pulp dep i purescript-quickcheck
+bower install purescript-quickcheck
 pulp psci
 ```
 


### PR DESCRIPTION
Replace references to 'pulp dep' with 'bower', since we're planning on
deprecating 'pulp dep'.

See also:

* https://github.com/bodil/pulp/pull/139
* https://github.com/bodil/pulp/issues/114