### PR TITLE
Update download page

### DIFF
--- a/_site/download/index.html
+++ b/_site/download/index.html
@@ -61,9 +61,9 @@ brew install purescript
 
   <h2>Stack</h2>
 
-  <p><a href="https://www.haskell.org/ghc/">GHC</a> 7.6.1 or newer is required to compile from source. The easiest way is to use <a href="https://github.com/commercialhaskell/stack">Stack</a>:</p>
+  <p><a href="https://www.haskell.org/ghc/">GHC</a> 7.10.1 or newer is required to compile from source. The easiest way is to use <a href="https://github.com/commercialhaskell/stack">Stack</a>:</p>
   <pre>
-stack install purescript
+stack install purescript --resolver=nightly
 </pre>
 
   <p>This will copy the compiler and utilities into <code>~/.local/bin</code>.</p>

--- a/download/index.html
+++ b/download/index.html
@@ -26,9 +26,9 @@ brew install purescript
 
   <h2>Stack</h2>
 
-  <p><a href="https://www.haskell.org/ghc/">GHC</a> 7.6.1 or newer is required to compile from source. The easiest way is to use <a href="https://github.com/commercialhaskell/stack">Stack</a>:</p>
+  <p><a href="https://www.haskell.org/ghc/">GHC</a> 7.10.1 or newer is required to compile from source. The easiest way is to use <a href="https://github.com/commercialhaskell/stack">Stack</a>:</p>
   <pre>
-stack install purescript
+stack install purescript --resolver=nightly
 </pre>
 
   <p>This will copy the compiler and utilities into <code>~/.local/bin</code>.</p>


### PR DESCRIPTION
* Use --resolver=nightly for stack installation (we want people to
  receive up-to-date versions)
* Update minimum required GHC version

Of course, the minimum required GHC version will only be 7.10.1 once psc
0.8.3 is released, so up to you whether to merge now or not.