### PR TITLE
Fixes "Getting Started" link in /download.

### DIFF
--- a/_site/download/index.html
+++ b/_site/download/index.html
@@ -36,7 +36,7 @@
   <main>
   <section>
   <blockquote>
-    <p>Are you new to PureScript? The best place to go is the <a href="./getting-started/">Getting Started guide</a>, a step-by-step primer to setting up and using PureScript.</p>
+    <p>Are you new to PureScript? The best place to go is the <a href="../learn/getting-started/">Getting Started guide</a>, a step-by-step primer to setting up and using PureScript.</p>
   </blockquote>
 </section>
 

--- a/download/index.html
+++ b/download/index.html
@@ -1,6 +1,6 @@
 <section>
   <blockquote>
-    <p>Are you new to PureScript? The best place to go is the <a href="./getting-started/">Getting Started guide</a>, a step-by-step primer to setting up and using PureScript.</p>
+    <p>Are you new to PureScript? The best place to go is the <a href="../learn/getting-started/">Getting Started guide</a>, a step-by-step primer to setting up and using PureScript.</p>
   </blockquote>
 </section>
 


### PR DESCRIPTION
I dun goofed, sorry. :sweat_drops: 

(It got accidentally changed in the last round of copy edits. The link is different on each page [relative URLs, following the rest of the site]; the link from /learn got copied into /download.)

Follow-up from #81.