### PR TITLE
Update download page to use stack unpack

### DIFF
--- a/_site/download/index.html
+++ b/_site/download/index.html
@@ -65,15 +65,28 @@ brew install purescript
 
   <h2>Stack</h2>
 
-  <p><a href="https://www.haskell.org/ghc/">GHC</a> 7.10.1 or newer is required to compile from source. The easiest way is to use <a href="https://github.com/commercialhaskell/stack">Stack</a>:</p>
+  <p><a href="https://www.haskell.org/ghc/">GHC</a> 7.10.1 or newer is required to compile from source. The easiest way is to use <a href="https://github.com/commercialhaskell/stack">Stack</a>.</p>
+
+  <p>Update the Hackage package index:</p>
   <pre>
-stack install purescript --resolver=nightly
-</pre>
+stack update</pre>
+
+  <p>Download the latest source distribution and place it into a new directory in the current directory:</p>
+  <pre>
+stack unpack purescript</pre>
+
+  <p>Compile and install PureScript:</p>
+  <pre>
+cd purescript-x.y.z   # (replace x.y.z with whichever version you just downloaded)
+stack install</pre>
 
   <p>This will copy the compiler and utilities into <code>~/.local/bin</code>.</p>
 
   <p>If you don't have Stack installed, there are install instructions <a href="https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md">here</a>.</p>
 
+  <p>You can also install a specific version by specifying it in the <code>stack unpack</code> step. For example, to install 0.8.5, use:</p>
+  <pre>
+  stack unpack purescript-0.8.5</pre>
 </section>
 
 <section>

--- a/_site/learn/eff/index.html
+++ b/_site/learn/eff/index.html
@@ -36,7 +36,7 @@
   <main>
   <section class="article">
   <h2>Handling Native Effects with the Eff Monad</h2>
-  <div class="meta">By Phil Freeman, published on July 16, 2015</div>
+  <div class="meta">By Phil Freeman, published on May 24, 2016</div>
 
   <p>In this post, I’m going to talk about PureScript’s hybrid approach to handling side-effects.</p>
 <p>As in Haskell, values in PureScript do not have side-effects by default, and there are a number of techniques for handling “non-native” side-effects. Such techniques include the use of things like monoids, monads, applicative functors and arrows, but I’m not going to talk about those here. I’m going to talk about how PureScript handles “native” effects, i.e. effects which are provided by the runtime system, and which cannot be emulated by pure functions.</p>
@@ -63,15 +63,15 @@
 
 <span class="kw">import </span><span class="dt">Control.Monad.Eff</span>
 <span class="kw">import </span><span class="dt">Control.Monad.Eff.Random</span> (random)
-<span class="kw">import </span><span class="dt">Control.Monad.Eff.Console</span> (print)
+<span class="kw">import </span><span class="dt">Control.Monad.Eff.Console</span> (logShow)
 
 printRandom <span class="fu">=</span> <span class="kw">do</span>
   n <span class="ot">&lt;-</span> random
-  print n</code></pre></div>
+  logShow n</code></pre></div>
 <p>This example requires the <a href="https://pursuit.purescript.org/packages/purescript-console/"><code>purescript-console</code></a> and <a href="https://pursuit.purescript.org/packages/purescript-random/"><code>purescript-random</code></a> dependencies to be installed:</p>
 <pre><code>pulp init
 bower install --save purescript-console purescript-random</code></pre>
-<p>If you save this file as <code>RandomExample.purs</code>, you will be able to compile and run it using PSCi:</p>
+<p>If you save this file as <code>src/RandomExample.purs</code>, you will be able to compile and run it using PSCi:</p>
 <pre><code>pulp psci
 
 &gt; import RandomExample
@@ -81,19 +81,20 @@ bower install --save purescript-console purescript-random</code></pre>
 <p>This program uses <code>do</code>-notation to combine two types of native effects provided by the Javascript runtime: random number generation and console IO.</p>
 <h4 id="extensible-records-and-extensible-effects">Extensible Records and Extensible Effects</h4>
 <p>We can inspect the type of <code>printRandom</code> by using the <code>:type command</code></p>
-<pre><code>&gt; :type RandomExample.main</code></pre>
+<pre><code>&gt; import RandomExample
+&gt; :type main</code></pre>
 <p>The type of <code>main</code> will be printed to the console. You should see a type which looks like this:</p>
 <pre><code>forall e. Eff (console :: CONSOLE, random :: RANDOM | e) Unit</code></pre>
 <p>This type looks quite complicated, but is easily explained by analogy with PureScript’s extensible records system.</p>
 <p>Consider a simple function which uses extensible records:</p>
-<div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell">fullName person <span class="fu">=</span> person<span class="fu">.</span>firstName <span class="fu">++</span> <span class="st">&quot; &quot;</span> <span class="fu">++</span> person<span class="fu">.</span>lastName</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell">fullName person <span class="fu">=</span> person<span class="fu">.</span>firstName <span class="fu">&lt;&gt;</span> <span class="st">&quot; &quot;</span> <span class="fu">&lt;&gt;</span> person<span class="fu">.</span>lastName</code></pre></div>
 <p>This function creates a full name string from an object containing <code>firstName</code> and <code>lastName</code> properties. If you find the type of this function in PSCi as before, you will see this:</p>
-<pre><code>forall t. { firstName :: String, lastName :: String | t } -&gt; String </code></pre>
+<pre><code>forall t. { firstName :: String, lastName :: String | t } -&gt; String</code></pre>
 <p>The readable version of this type is “<code>fullName</code> takes an object with <code>firstName</code> and <code>lastName</code> properties <em>and any other properties</em> and returns a <code>String</code>”.</p>
 <p>That is, <code>fullName</code> does not care if you pass an object with <em>more</em> properties, as long as the <code>firstName</code> and <code>lastName</code> properties are present:</p>
 <pre><code>&gt; fullName { firstName: &quot;Phil&quot;, lastName: &quot;Freeman&quot;, location: &quot;Los Angeles&quot; }
 Phil Freeman</code></pre>
-<p>Similarly, the type of <code>printRandom</code> above can be interpreted as follows: “<code>printRandom</code> is a side-effecting computation, which can be run in any environment which supports random number generation and console IO, <em>and any other types of side effect</em>, and which yields a value of type <code>Unit</code>”.</p>
+<p>Similarly, the type of <code>printRandom</code> above can be interpreted as follows: “<code>printRandom</code> is an effectful computation, which can be run in any environment which supports random number generation and console IO, <em>and any other types of side effect</em>, and which yields a value of type <code>Unit</code>”.</p>
 <p>This is the origin of the name “extensible effects”: we can always <em>extend</em> the set of side-effects, as long as we can support the set of effects that we need.</p>
 <h4 id="interleaving-effects">Interleaving Effects</h4>
 <p>This extensibility allows code in the <code>Eff</code> monad to <em>interleave</em> different types of effects.</p>
@@ -101,10 +102,10 @@ Phil Freeman</code></pre>
 <pre><code>forall e1. Eff (random :: RANDOM | e1) Number</code></pre>
 <p>which is <em>not</em> the same as the type of <code>main</code>.</p>
 <p>However, we can instantiate the polymorphic type variable in such a way that the types do match. If we choose <code>e1 ~ (console :: CONSOLE | e)</code>, then the two rows are equal, up to reordering.</p>
-<p>Similarly, <code>print</code> has a type which can be instantiated to match the type of <code>printRandom</code>:</p>
-<pre><code>forall a e2. (Show a) =&gt; a -&gt; Eff (console :: CONSOLE | e2) Unit</code></pre>
+<p>Similarly, <code>logShow</code> has a type which can be instantiated to match the type of <code>printRandom</code>:</p>
+<pre><code>forall a e2. Show a =&gt; a -&gt; Eff (console :: CONSOLE | e2) Unit</code></pre>
 <p>This time we have to choose <code>e2 ~ random :: RANDOM | e</code>.</p>
-<p>The key is that we don’t have to give a type for <code>printRandom</code> in order to be able to find these substitutions. <code>psc</code> will find a most general type for <code>printRandom</code> given the polymorphic types of <code>random</code> and <code>print</code>.</p>
+<p>The key is that we don’t have to give a type for <code>printRandom</code> in order to be able to find these substitutions. <code>psc</code> will find a most general type for <code>printRandom</code> given the polymorphic types of <code>random</code> and <code>logShow</code>.</p>
 <h4 id="aside-the-kind-of-eff">Aside: The Kind of Eff</h4>
 <p>Looking at the <a href="https://github.com/purescript/purescript-eff/blob/master/src/Control/Monad/Eff.purs">source code</a>, you will see the following definition for <code>Eff</code>:</p>
 <pre><code>foreign import Eff :: # ! -&gt; * -&gt; *</code></pre>
@@ -117,32 +118,34 @@ Phil Freeman</code></pre>
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="ot">main ::</span> <span class="dt">Eff</span> (<span class="ot">console ::</span> <span class="dt">CONSOLE</span>,<span class="ot"> random ::</span> <span class="dt">RANDOM</span>) <span class="dt">Unit</span>
 main <span class="fu">=</span> <span class="kw">do</span>
   n <span class="ot">&lt;-</span> random
-  print n</code></pre></div>
+  logShow n</code></pre></div>
 <p>(note the lack of a type variable here), then we cannot accidentally include a subcomputation which makes use of a different type of effect. This is an advantage of <code>Eff</code> over Haskell’s more coarsely-grained <code>IO</code> monad.</p>
 <h4 id="handlers-and-actions">Handlers and Actions</h4>
-<p>Rows of effects can also appear on the left-hand side of a function arrow. This is what differentiates actions like <code>print</code> and <code>random</code> from effect <em>handlers</em>.</p>
+<p>Rows of effects can also appear on the left-hand side of a function arrow. This is what differentiates actions like <code>logShow</code> and <code>random</code> from effect <em>handlers</em>.</p>
 <p>While actions <em>add</em> to the set of required effects, a handler <code>subtracts</code> effects from the set.</p>
 <p>Consider <code>catchException</code> from the <a href="https://pursuit.purescript.org/packages/purescript-exceptions/"><code>purescript-exceptions</code></a> package:</p>
-<div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="ot">catchException ::</span> forall a e<span class="fu">.</span> (<span class="dt">Error</span> <span class="ot">-&gt;</span> <span class="dt">Eff</span> e a) <span class="ot">-&gt;</span> 
-                              <span class="dt">Eff</span> (<span class="ot">err ::</span> <span class="dt">EXCEPTION</span> <span class="fu">|</span> e) a <span class="ot">-&gt;</span> 
-                              <span class="dt">Eff</span> e a</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell">catchException
+<span class="ot">  ::</span> forall a e
+   <span class="fu">.</span> (<span class="dt">Error</span> <span class="ot">-&gt;</span> <span class="dt">Eff</span> e a)
+  <span class="ot">-&gt;</span> <span class="dt">Eff</span> (<span class="ot">err ::</span> <span class="dt">EXCEPTION</span> <span class="fu">|</span> e) a
+  <span class="ot">-&gt;</span> <span class="dt">Eff</span> e a</code></pre></div>
 <p>Note that the type of the effect on the right of the final function arrow requires <em>fewer</em> effects than the effect to its left. Namely, <code>catchException</code> <em>removes</em> the <code>EXCEPTION</code> effect from the set of required effects.</p>
 <p>This is useful, because the type system can be used to delimit portions of code which require a particular effect, and then to wrap that code in a handler, embedding it inside a piece of code which does not use that effect.</p>
 <p>For example, we can write a piece of code which uses exceptions, then wrap that code using <code>catchException</code> to embed the computation in a piece of code which does not use exceptions.</p>
 <p><code>purescript-eff</code> also defines the handler <code>runPure</code>, which takes a computation with <em>no</em> side-effects, and safely evaluates it as a pure value:</p>
-<pre><code>type Pure a = forall e. Eff e a
+<pre><code>type Pure a = Eff () a
 
 runPure :: forall a. Pure a -&gt; a</code></pre>
 <p>For example, we can define a version of the division function for which division by zero results in an exception:</p>
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">module</span> <span class="dt">ErrorsExample</span> <span class="kw">where</span>
 
 <span class="kw">import </span><span class="dt">Prelude</span>
-<span class="kw">import </span><span class="dt">Control.Monad.Eff</span>
-<span class="kw">import </span><span class="dt">Control.Monad.Eff.Exception</span>
+<span class="kw">import </span><span class="dt">Control.Monad.Eff</span> (<span class="dt">Eff</span>)
+<span class="kw">import </span><span class="dt">Control.Monad.Eff.Exception</span> (<span class="dt">EXCEPTION</span>, throw)
 
 <span class="ot">divide ::</span> forall e<span class="fu">.</span> <span class="dt">Int</span> <span class="ot">-&gt;</span> <span class="dt">Int</span> <span class="ot">-&gt;</span> <span class="dt">Eff</span> (<span class="ot">err ::</span> <span class="dt">EXCEPTION</span> <span class="fu">|</span> e) <span class="dt">Int</span>
 divide _ <span class="dv">0</span> <span class="fu">=</span> throw <span class="st">&quot;Division by zero&quot;</span>
-divide n m <span class="fu">=</span> return (n <span class="fu">/</span> m)</code></pre></div>
+divide n m <span class="fu">=</span> pure (n <span class="fu">/</span> m)</code></pre></div>
 <p>If we have already defined this function, we can use the <code>runPure</code> and <code>catchException</code> handlers to define a version of <code>divide</code> which reports its errors using <code>Either</code>:</p>
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">import </span><span class="dt">Data.Either</span>
 
@@ -169,32 +172,32 @@ dividePure n m <span class="fu">=</span> runPure (catchException (return <span c
   <span class="cf">return</span> f<span class="op">;</span>
 <span class="op">};</span></code></pre></div>
 <h4 id="the-eff-monad-is-magic">The Eff Monad is Magic</h4>
-<p>The <code>psc</code> compiler has special support for the <code>Eff</code> monad. Ordinarily, a chain of monadic binds might result in poor performance when executed in <code>nodejs</code> or in the browser. However, the compiler can generate code for the <code>Eff</code> monad without explicit calls to the monadic bind function <code>&gt;&gt;=</code>.</p>
+<p>The <code>psc</code> compiler has special support for the <code>Eff</code> monad. Ordinarily, a chain of monadic binds might result in poor performance when executed in Node or in the browser. However, the compiler can generate code for the <code>Eff</code> monad without explicit calls to the monadic bind function <code>&gt;&gt;=</code>.</p>
 <p>Take the random number generation from the start of the post. If we compile this example without optimizations, we end up the following Javascript:</p>
-<div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="kw">var</span> main <span class="op">=</span> 
+<div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="kw">var</span> main <span class="op">=</span>
   Prelude[<span class="st">&quot;&gt;&gt;=&quot;</span>]
     (<span class="va">Control_Monad_Eff</span>.<span class="at">monadEff</span>())
 	(<span class="va">Control_Monad_Eff_Random</span>.<span class="at">random</span>)
 	(<span class="kw">function</span> (n) <span class="op">{</span>
-      <span class="cf">return</span> <span class="va">Control_Monad_Eff_Console</span>.<span class="at">print</span>(<span class="va">Prelude</span>.<span class="at">showNumber</span>())(n)<span class="op">;</span>
+      <span class="cf">return</span> <span class="va">Control_Monad_Eff_Console</span>.<span class="at">logShow</span>(<span class="va">Prelude</span>.<span class="at">showNumber</span>())(n)<span class="op">;</span>
     <span class="op">}</span>)<span class="op">;</span></code></pre></div>
 <p>However, if we use the default optimizations, the calls to <code>Eff</code>’s monadic bind function are inlined, resulting the following tidier Javascript:</p>
 <div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="kw">var</span> main <span class="op">=</span> <span class="kw">function</span> <span class="at">__do</span>() <span class="op">{</span>
   <span class="kw">var</span> n <span class="op">=</span> <span class="va">Control_Monad_Eff_Random</span>.<span class="at">random</span>()<span class="op">;</span>
-  <span class="cf">return</span> <span class="va">Control_Monad_Eff_Console</span>.<span class="at">print</span>(<span class="va">Prelude</span>.<span class="at">showNumber</span>())(n)()<span class="op">;</span>
+  <span class="cf">return</span> <span class="va">Control_Monad_Eff_Console</span>.<span class="at">logShow</span>(<span class="va">Prelude</span>.<span class="at">showNumber</span>())(n)()<span class="op">;</span>
 <span class="op">};</span></code></pre></div>
 <p>While this is a small improvement, the benefit is greater when using multiple nested calls to <code>&gt;&gt;=</code>.</p>
 <p>The improvement is even more marked when optimizations are used in conjunction with tail call elimination. Consider the following recursive program which prints an increasing sequence of numbers to the console:</p>
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell">go n <span class="fu">=</span> <span class="kw">do</span>
-  print n
+  logShow n
   go (n <span class="fu">+</span> <span class="dv">1</span>)
 
 main <span class="fu">=</span> go <span class="dv">1</span></code></pre></div>
 <p>Without optimizations, the compiler generates the following Javascript, which fails after a few iterations with a stack overflow:</p>
-<div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="kw">var</span> go <span class="op">=</span> 
+<div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="kw">var</span> go <span class="op">=</span>
   Prelude[<span class="st">&quot;&gt;&gt;=&quot;</span>]
     (<span class="va">Control_Monad_Eff</span>.<span class="at">monadEff</span>())
-	(<span class="va">Control_Monad_Eff_Console</span>.<span class="at">print</span>(<span class="va">Prelude</span>.<span class="at">showNumber</span>())(n))
+	(<span class="va">Control_Monad_Eff_Console</span>.<span class="at">logShow</span>(<span class="va">Prelude</span>.<span class="at">showNumber</span>())(n))
 	(<span class="kw">function</span> (_) <span class="op">{</span>
       <span class="cf">return</span> <span class="at">go</span>(n <span class="op">+</span> <span class="dv">1</span>)<span class="op">;</span>
     <span class="op">}</span>)<span class="op">;</span></code></pre></div>
@@ -203,7 +206,7 @@ main <span class="fu">=</span> go <span class="dv">1</span></code></pre></div>
   <span class="cf">return</span> <span class="kw">function</span> <span class="at">__do</span>() <span class="op">{</span>
     <span class="kw">var</span> n <span class="op">=</span> __copy_n<span class="op">;</span>
     <span class="dt">tco</span><span class="op">:</span> <span class="cf">while</span> (<span class="kw">true</span>) <span class="op">{</span>
-      <span class="va">Control_Monad_Eff_Console</span>.<span class="at">print</span>(<span class="va">Prelude</span>.<span class="at">showNumber</span>())(n)()<span class="op">;</span>
+      <span class="va">Control_Monad_Eff_Console</span>.<span class="at">logShow</span>(<span class="va">Prelude</span>.<span class="at">showNumber</span>())(n)()<span class="op">;</span>
       <span class="kw">var</span> __tco_n <span class="op">=</span> n <span class="op">+</span> <span class="dv">1</span><span class="op">;</span>
       n <span class="op">=</span> __tco_n<span class="op">;</span>
       <span class="cf">continue</span> tco<span class="op">;</span>
@@ -217,11 +220,11 @@ main <span class="fu">=</span> go <span class="dv">1</span></code></pre></div>
 collatz n <span class="fu">=</span> pureST <span class="kw">do</span>
   r <span class="ot">&lt;-</span> newSTRef n
   count <span class="ot">&lt;-</span> newSTRef <span class="dv">0</span>
-  untilE <span class="fu">$</span> <span class="kw">do</span>
-    modifySTRef count <span class="fu">$</span> (<span class="fu">+</span>) <span class="dv">1</span>
+  untilE <span class="kw">do</span>
+    modifySTRef count (_ <span class="fu">+</span> <span class="dv">1</span>)
     m <span class="ot">&lt;-</span> readSTRef r
     writeSTRef r <span class="fu">$</span> <span class="kw">if</span> m <span class="ot">`mod`</span> <span class="dv">2</span> <span class="fu">==</span> <span class="dv">0</span> <span class="kw">then</span> m <span class="fu">/</span> <span class="dv">2</span> <span class="kw">else</span> <span class="dv">3</span> <span class="fu">*</span> m <span class="fu">+</span> <span class="dv">1</span>
-    return <span class="fu">$</span> m <span class="fu">==</span> <span class="dv">1</span>
+    pure (m <span class="fu">==</span> <span class="dv">1</span>)
   readSTRef count</code></pre></div>
 <p>In this case, <code>psc</code> notices that the mutable variables <code>r</code> and <code>count</code> are scoped by <code>runST</code> and so can safely be turned into local mutable variables.</p>
 <p>The resulting Javascript is surprisingly short:</p>
@@ -235,8 +238,7 @@ collatz n <span class="fu">=</span> pureST <span class="kw">do</span>
         <span class="kw">var</span> m <span class="op">=</span> r<span class="op">;</span>
         r <span class="op">=</span> (m <span class="op">%</span> <span class="dv">2</span> <span class="op">===</span> <span class="dv">0</span>) <span class="op">?</span> m / <span class="dv">2</span> : <span class="dv">3</span> <span class="op">*</span> m <span class="op">+</span> <span class="dv">1</span><span class="op">;</span>
         <span class="cf">return</span> m <span class="op">===</span> <span class="dv">1</span><span class="op">;</span>
-      <span class="op">}</span>)()) <span class="op">{</span>
-	  <span class="op">};</span>
+      <span class="op">}</span>)()) <span class="op">{</span> <span class="op">};</span>
       <span class="cf">return</span> <span class="op">{};</span>
     <span class="op">}</span>)()<span class="op">;</span>
     <span class="cf">return</span> count<span class="op">;</span>

--- a/_site/learn/ffi/index.html
+++ b/_site/learn/ffi/index.html
@@ -46,6 +46,8 @@
 <p>Let’s take the following simple module as an example:</p>
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">module</span> <span class="dt">Test</span> <span class="kw">where</span>
 
+<span class="kw">import </span><span class="dt">Prelude</span>
+
 gcd<span class="ot"> ::</span> <span class="dt">Int</span> <span class="ot">-&gt;</span> <span class="dt">Int</span> <span class="ot">-&gt;</span> <span class="dt">Int</span>
 gcd n m <span class="fu">|</span> n <span class="fu">==</span> <span class="dv">0</span> <span class="fu">=</span> m
 gcd n m <span class="fu">|</span> m <span class="fu">==</span> <span class="dv">0</span> <span class="fu">=</span> n
@@ -69,28 +71,22 @@ gcd n m <span class="fu">=</span> gcd (m <span class="fu">-</span> n) n</code></
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell">example' <span class="fu">=</span> <span class="dv">100</span></code></pre></div>
 <p>generates the following Javascript:</p>
 <div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="kw">var</span> example$prime <span class="op">=</span> <span class="dv">100</span><span class="op">;</span></code></pre></div>
-<p>This scheme also applies to names of infix operators:</p>
-<div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell">(<span class="fu">%</span>) a b <span class="fu">=</span> <span class="fu">...</span></code></pre></div>
-<p>generates</p>
-<div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="kw">var</span> $percent <span class="op">=</span> <span class="kw">function</span>(a) <span class="op">{</span> ... <span class="op">}</span></code></pre></div>
 <h4 id="calling-javascript-from-purescript">Calling Javascript from PureScript</h4>
 <p>Javascript values and functions can be used from PureScript by using the FFI. The problem becomes how to choose suitable types for values originating in Javascript.</p>
 <p>The general rule regarding types is that you can enforce as little or as much type safety as you like when using the FFI, but you should be careful to avoid common pitfalls when dealing with Javascript values, like the possibility of null or undefined values being returned from a Javascript function. Functions defined in the Prelude and core libraries tend to err on the side of type safety where possible.</p>
 <h4 id="foreign-modules">Foreign Modules</h4>
 <p>In PureScript, JavaScript code is wrapped using a <em>foreign module</em>. A foreign module is just a CommonJS module which is associated with a PureScript module. Foreign modules are required to adhere to certain conventions:</p>
 <ul>
-<li>The module must contain a comment of the form <code>// module ModuleName</code>, which associates the foreign module with its companion PureScript module.</li>
+<li>The name of the foreign module must be the same as its companion PureScript module, with its extension changed to <code>.js</code>. This associates the foreign module with the PureScript module.</li>
 <li>All exports must be of the form <code>exports.name = value;</code>, specified at the top level.</li>
 </ul>
 <p>Here is an example, where we export a function which computes interest amounts from a foreign module:</p>
 <div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="st">&quot;use strict&quot;</span><span class="op">;</span>
 
-<span class="co">// module Interest</span>
-
 <span class="va">exports</span>.<span class="at">calculateInterest</span> <span class="op">=</span> <span class="kw">function</span>(amount) <span class="op">{</span>
   <span class="cf">return</span> amount <span class="op">*</span> <span class="fl">0.1</span><span class="op">;</span>
 <span class="op">};</span></code></pre></div>
-<p>This file should be saved as <code>src/Interest.js</code>. The corresponding PureScript module <code>Interest</code> will be saved in <code>src/Interest.purs</code> (these filenames are merely conventions, but are used by certain tools, such as the Pulp build tool), and will look like this:</p>
+<p>This file should be saved as <code>src/Interest.js</code>. The corresponding PureScript module <code>Interest</code> will be saved in <code>src/Interest.purs</code>, and will look like this:</p>
 <pre class="purescript"><code>module Interest where
 
 foreign import calculateInterest :: Number -&gt; Number</code></pre>
@@ -100,13 +96,13 @@ foreign import calculateInterest :: Number -&gt; Number</code></pre>
 <p>Suppose we wanted to modify our <code>calculateInterest</code> function to take a second argument:</p>
 <div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="st">&quot;use strict&quot;</span><span class="op">;</span>
 
-<span class="co">// module Interest</span>
-
 <span class="va">exports</span>.<span class="at">calculateInterest</span> <span class="op">=</span> <span class="kw">function</span>(amount<span class="op">,</span> months) <span class="op">{</span>
   <span class="cf">return</span> amount <span class="op">*</span> <span class="va">Math</span>.<span class="at">exp</span>(<span class="fl">0.1</span><span class="op">,</span> months)<span class="op">;</span>
 <span class="op">};</span></code></pre></div>
 <p>A correct <code>foreign import</code> declaration now should use a foreign type whose runtime representation correctly handles functions of multiple arguments. The <code>purescript-functions</code> package provides a collection of such types for function arities from 0 to 10:</p>
 <pre class="purescript"><code>module Interest where
+
+import Data.Function (Fn2)
 
 foreign import calculateInterest :: Fn2 Number Number Number</code></pre>
 <p>Here, the <code>Fn2</code> type constructor is used to wrap Javascript functions of two arguments. We can write a curried wrapper function in PureScript which will allow partial application:</p>
@@ -114,8 +110,6 @@ foreign import calculateInterest :: Fn2 Number Number Number</code></pre>
 calculateInterestCurried = runFn2 calculateInterest</code></pre>
 <p>An alternative is to use curried functions in the native module, using multiple nested functions, each with a single argument, as the runtime representation of the function type constructor <code>(-&gt;)</code> dictates:</p>
 <div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="st">&quot;use strict&quot;</span><span class="op">;</span>
-
-<span class="co">// module Interest</span>
 
 <span class="va">exports</span>.<span class="at">calculateInterest</span> <span class="op">=</span> <span class="kw">function</span>(amount) <span class="op">{</span>
   <span class="cf">return</span> <span class="kw">function</span>(months) <span class="op">{</span>
@@ -129,9 +123,10 @@ calculateInterestCurried = runFn2 calculateInterest</code></pre>
 <p>For example, let’s write a simple PureScript function with a constrained type, and look at the generated Javascript.</p>
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">module</span> <span class="dt">Test</span> <span class="kw">where</span>
 
-<span class="kw">import </span><span class="dt">Data.Tuple</span>
+<span class="kw">import </span><span class="dt">Prelude</span>
+<span class="kw">import </span><span class="dt">Data.Tuple</span> (<span class="dt">Tuple</span>(..))
 
-<span class="ot">inOrder ::</span> forall a<span class="fu">.</span> (<span class="dt">Ord</span> a) <span class="ot">=&gt;</span> a <span class="ot">-&gt;</span> a <span class="ot">-&gt;</span> <span class="dt">Tuple</span> a a
+<span class="ot">inOrder ::</span> forall a<span class="fu">.</span> <span class="dt">Ord</span> a <span class="ot">=&gt;</span> a <span class="ot">-&gt;</span> a <span class="ot">-&gt;</span> <span class="dt">Tuple</span> a a
 inOrder a1 a2 <span class="fu">|</span> a1 <span class="fu">&lt;</span> a2 <span class="fu">=</span> <span class="dt">Tuple</span> a1 a2
 inOrder a1 a2 <span class="fu">=</span> <span class="dt">Tuple</span> a2 a1</code></pre></div>
 <p>The generated Javascript looks like this:</p>

--- a/_site/learn/generic/index.html
+++ b/_site/learn/generic/index.html
@@ -43,8 +43,8 @@
 <p>PureScript’s generics are supported by the <code>purescript-generics</code> library, and in particular, the <code>Data.Generic.Generic</code> type class:</p>
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">class</span> <span class="dt">Generic</span> a <span class="kw">where</span>
 <span class="ot">  toSignature ::</span> <span class="dt">Proxy</span> a <span class="ot">-&gt;</span> <span class="dt">GenericSignature</span>
-<span class="ot">  toSpine ::</span> a <span class="ot">-&gt;</span> <span class="dt">GenericSpine</span>
-<span class="ot">  fromSpine ::</span> <span class="dt">GenericSpine</span> <span class="ot">-&gt;</span> <span class="dt">Maybe</span> a</code></pre></div>
+<span class="ot">  toSpine     ::</span> a <span class="ot">-&gt;</span> <span class="dt">GenericSpine</span>
+<span class="ot">  fromSpine   ::</span> <span class="dt">GenericSpine</span> <span class="ot">-&gt;</span> <span class="dt">Maybe</span> a</code></pre></div>
 <p><code>Generic</code> defines three functions:</p>
 <ul>
 <li><code>toSignature</code> creates a generic <em>signature</em> for a type. We can think of this as a representation of a type at runtime.</li>
@@ -85,7 +85,7 @@ derive <span class="kw">instance</span><span class="ot"> genericPerson ::</span>
     return <span class="fu">$</span> <span class="dt">Person</span> { name, location }</code></pre></div>
 <p>This is not too bad, but real-world records often contain many more fields. Let’s see how to verify the same data using <code>Generic</code>.</p>
 <p>The <code>purescript-foreign-generic</code> library defines a function <code>readGeneric</code>, with the following type:</p>
-<div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="ot">readGeneric ::</span> forall a<span class="fu">.</span> (<span class="dt">Generic</span> a) <span class="ot">=&gt;</span> <span class="dt">Options</span> <span class="ot">-&gt;</span> <span class="dt">Foreign</span> <span class="ot">-&gt;</span> <span class="dt">F</span> a</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="ot">readGeneric ::</span> forall a<span class="fu">.</span> <span class="dt">Generic</span> a <span class="ot">=&gt;</span> <span class="dt">Options</span> <span class="ot">-&gt;</span> <span class="dt">Foreign</span> <span class="ot">-&gt;</span> <span class="dt">F</span> a</code></pre></div>
 <p>The <code>Options</code> type here is based on the options record from Haskell’s <code>aeson</code> library. For our purposes, the default options will work, but we need to turn on the <code>unwrapNewtypes</code> option, so that our <code>newtype</code> constructor gets ignored during serialization:</p>
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="ot">myOptions ::</span> <span class="dt">Options</span>
 myOptions <span class="fu">=</span> defaultOptions { unwrapNewtypes <span class="fu">=</span> true }</code></pre></div>

--- a/_site/learn/getting-started/index.html
+++ b/_site/learn/getting-started/index.html
@@ -36,7 +36,7 @@
   <main>
   <section class="article">
   <h2>Getting Started with PureScript</h2>
-  <div class="meta">By Phil Freeman, published on December 13, 2015</div>
+  <div class="meta">By Phil Freeman, published on May 24, 2016</div>
 
   <p>Welcome to the PureScript community blog! In this first post, I’m going to walk through the basics of getting set up to use the PureScript compiler <code>psc</code>, and its interactive mode <code>psci</code>.</p>
 <p>I’ll start with the installation of the compiler and Pulp build tool, and then go through the basic usage of <code>psci</code>, working towards a solution of problem 1 from <a href="http://projecteuler.net/problem=1">Project Euler</a>.</p>
@@ -73,14 +73,8 @@ You should add some tests.
 <h4 id="working-in-psci">Working in PSCI</h4>
 <p>PSCi is the interactive mode of PureScript. It is useful for working with pure computations, and for testing ideas.</p>
 <p>Open PSCi by typing <code>pulp psci</code> at the command line. Pulp will create a file in your directory called <code>.psci</code>, which contains instructions to PSCi to load your modules and dependencies. If you invoke the PSCi executable directly, you would need to load these files by hand.</p>
-<pre><code> ____                 ____            _       _   
-|  _ \ _   _ _ __ ___/ ___|  ___ _ __(_)_ __ | |_ 
-| |_) | | | | '__/ _ \___ \ / __| '__| | '_ \| __|
-|  __/| |_| | | |  __/___) | (__| |  | | |_) | |_ 
-|_|    \__,_|_|  \___|____/ \___|_|  |_| .__/ \__|
-                                       |_|        
-
-:? shows help
+<pre><code>PSCi, version 0.9.0
+Type :? for help
 &gt;</code></pre>
 <p>As the introduction indicates, you can type <code>:?</code> to see a list of commands:</p>
 <pre><code>The following commands are available:
@@ -89,8 +83,6 @@ You should add some tests.
 :quit                     Quit PSCi
 :reset                    Discard all imported modules and declared bindings
 :browse      &lt;module&gt;     See all functions in &lt;module&gt;
-:load        &lt;file&gt;       Load &lt;file&gt; for importing
-:foreign     &lt;file&gt;       Load foreign module &lt;file&gt;
 :type        &lt;expr&gt;       Show the type of &lt;expr&gt;
 :kind        &lt;type&gt;       Show the kind of &lt;type&gt;
 :show        import       Show all imported modules
@@ -100,12 +92,15 @@ Further information is available on the PureScript wiki:
 --&gt; https://github.com/purescript/purescript/wiki/psci</code></pre>
 <p>We will use a selection of these commands during this tutorial.</p>
 <p>Start by pressing the Tab key to use the autocompletion feature. You will see a collection of names of functions from the Prelude which are available to use.</p>
-<p>To see the type of one of these values, use the <code>:type</code> command, followed by a space, followed by the name of the value:</p>
-<pre><code>&gt; :type Prelude.map
+<p>To see the type of one of these values, first import the appropriate module using the <code>import</code> command. Then, use the <code>:type</code> command, followed by a space, followed by the name of the value:</p>
+<pre><code>&gt; import Prelude
+&gt; :type map
 forall a b f. (Prelude.Functor f) =&gt; (a -&gt; b) -&gt; f a -&gt; f b
-&gt; :type Data.List.zip
+
+&gt; import Data.List
+&gt; :type zip
 forall a b. Data.List.List a -&gt; Data.List.List b -&gt; Data.List.List (Data.Tuple.Tuple a b)</code></pre>
-<p>We will be using some of the functions from the <code>Prelude</code> and <code>Data.List</code> modules, so import those by using the <code>import</code> keyword:</p>
+<p>We will be using some of the functions from the <code>Prelude</code> and <code>Data.List</code> modules, so make sure you have imported those by using the <code>import</code> keyword:</p>
 <pre><code>import Prelude
 import Data.List</code></pre>
 <p>Note that using <code>Tab</code> to autocomplete names can be a useful time-saving device in <code>psci</code>.</p>
@@ -138,7 +133,7 @@ See ya!</code></pre>
 <h4 id="compiling-a-solution">Compiling a Solution</h4>
 <p>Now that we’ve seen how to use <code>psci</code> to reach the answer, let’s move our solution into a source file and compile it.</p>
 <p>Create a new text file <code>src/Euler.purs</code> and copy the following code:</p>
-<pre class="purescript"><code>module Euler1 where
+<pre class="purescript"><code>module Euler where
 
 import Prelude
 
@@ -152,7 +147,8 @@ multiples = filter (\n -&gt; mod n 3 == 0 || mod n 5 == 0) ns
 answer = sum multiples</code></pre>
 <p>It is possible to load this file directly into PSCi and to continue working:</p>
 <pre><code>pulp psci
-&gt; Euler1.answer
+&gt; import Euler
+&gt; answer
 233168
 &gt; :quit
 See ya!</code></pre>
@@ -166,7 +162,8 @@ See ya!</code></pre>
 <pre class="purescript"><code>module Test.Main where
 
 import Prelude
-import Euler1 (answer)
+
+import Euler (answer)
 import Test.Assert (assert)
 
 main = do
@@ -178,14 +175,15 @@ main = do
 <pre class="purescript"><code>module Main where
 
 import Prelude
-import Euler1
-import Control.Monad.Eff.Console
+
+import Euler (answer)
+import Control.Monad.Eff.Console (log)
 
 main = do
-  log (&quot;The answer is &quot; ++ show answer)</code></pre>
+  log (&quot;The answer is &quot; &lt;&gt; show answer)</code></pre>
 <p>The <code>pulp run</code> command can be used to compile and run the <code>Main</code> module:</p>
 <pre><code>&gt; pulp run
-* Building project in /Users/paf31/Documents/Code/purescript/pulp-test
+* Building project in pulp-test
 * Build successful.
 The answer is 233168</code></pre>
 <h4 id="conclusion">Conclusion</h4>

--- a/_site/learn/quickcheck/index.html
+++ b/_site/learn/quickcheck/index.html
@@ -59,21 +59,21 @@ unit</code></pre>
 <p>This indicates 100 successful random test runs.</p>
 <h4 id="error-messages">Error Messages</h4>
 <p>Let’s see what happens when we try testing a broken property:</p>
-<pre><code>&gt; quickCheck \n -&gt; n + 1 == n </code></pre>
+<pre><code>&gt; quickCheck \n -&gt; n + 1 == n</code></pre>
 <p>You should see an exception printed to the console:</p>
 <pre><code>Error: Test 1 failed:
 Failed: Test returned false</code></pre>
 <p>That’s not a very helpful error, so let’s improve it:</p>
-<pre><code>&gt; quickCheck \n -&gt; n + 1 == n &lt;?&gt; &quot;Test failed for input &quot; ++ show n</code></pre>
+<pre><code>&gt; quickCheck \n -&gt; n + 1 == n &lt;?&gt; &quot;Test failed for input &quot; &lt;&gt; show n</code></pre>
 <p>This time you should see the following failure message:</p>
-<pre><code>Error: Test 1 failed: 
+<pre><code>Error: Test 1 failed:
 Test failed for input -654791</code></pre>
 <p>Alternatively, we could use the <code>===</code> operator, which provides a better error message:</p>
-<pre><code>&gt; quickCheck \n -&gt; n + 1 === n 
-Error: Test 1 failed: 
+<pre><code>&gt; quickCheck \n -&gt; n + 1 === n
+Error: Test 1 failed:
 -663820 /= -663821</code></pre>
 <h4 id="example-1---gcd-function">Example 1 - GCD Function</h4>
-<p>Let’s write an implementation of the <em>greatest common divisor</em> function in PSCi (you will need to enable multiline mode):</p>
+<p>Let’s write an implementation of the <em>greatest common divisor</em> function in PSCi (you will need to enable multiline mode by restarting PSCi with <code>--multi-line-mode</code>):</p>
 <pre><code>&gt; let
     gcd 0 n = n
     gcd n 0 = n
@@ -83,7 +83,7 @@ Error: Test 1 failed:
     gcd n m = gcd n (m - n)</code></pre>
 <p>Now let’s assert some basic properties that we expect to hold of the <code>gcd</code> function.</p>
 <pre><code>&gt; quickCheck \n -&gt; gcd n 1 === 1</code></pre>
-<p>This test should pass, but will take a while, because the standard random generator for integers which comes bundled with <code>purescript-quickcheck</code> generates integers in the range -1000000 to 1000000.</p>
+<p>This test should pass, but might take a while, because the standard random generator for integers which comes bundled with <code>purescript-quickcheck</code> generates integers in the range -1000000 to 1000000.</p>
 <p>We can modify our test to only consider small integers:</p>
 <pre><code>&gt; quickCheck \n -&gt; gcd (n / 1000) 1 === 1</code></pre>
 <p>This time, the test should complete quickly. However, we’ve coupled the generation of our data (<code>/ 1000</code>) with the property we’re testing, which is against the spirit of QuickCheck. A better approach is to define a <code>newtype</code> which can be used to generate small integers.</p>
@@ -91,6 +91,7 @@ Error: Test 1 failed:
 <pre><code>module SmallInt where
 
 import Prelude
+
 import Test.QuickCheck
 import Test.QuickCheck.Arbitrary
 
@@ -100,7 +101,7 @@ runInt :: SmallInt -&gt; Int
 runInt (SmallInt i) = i
 
 instance arbSmallInt :: Arbitrary SmallInt where
-  arbitrary = (/ 1000) &lt;$&gt; arbitrary</code></pre>
+  arbitrary = map (_ / 1000) arbitrary</code></pre>
 <p>Back in PSCi, we can now test properties without having to explicitly define how to generate our random data:</p>
 <pre><code>&gt; quickCheck \(SmallInt n) (SmallInt m) -&gt; gcd n m == gcd m n</code></pre>
 <p>The idea is that the particular scheme that is chosen to generate data should be indicated by the types of our function arguments, so <code>newtype</code>s can be quite useful when defining multiple data generation schemes for a single type.</p>
@@ -111,8 +112,8 @@ instance arbSmallInt :: Arbitrary SmallInt where
 <p>The first functor law says that if you map a function which does not modify its argument (the identity function) over a structure, then the structure should not be modified either.</p>
 <pre><code>&gt; import Data.Array
 
-&gt; let 
-    firstFunctorLaw :: [Int] -&gt; Boolean
+&gt; let
+    firstFunctorLaw :: Array Int -&gt; Boolean
     firstFunctorLaw arr = map id arr == arr
 
 &gt; quickCheck firstFunctorLaw
@@ -121,9 +122,9 @@ instance arbSmallInt :: Arbitrary SmallInt where
 unit</code></pre>
 <p>The second functor law says that mapping two functions over a structure one-by-one is equivalent to mapping their composition over the structure:</p>
 <pre><code>&gt; let
-    secondFunctorLaw :: (Int -&gt; Int) -&gt; (Int -&gt; Int) -&gt; [Int] -&gt; Boolean
+    secondFunctorLaw :: (Int -&gt; Int) -&gt; (Int -&gt; Int) -&gt; Array Int -&gt; Boolean
     secondFunctorLaw f g arr = map f (map g arr) == map (f &lt;&lt;&lt; g) arr
-  
+
 &gt; quickCheck secondFunctorLaw
 
 100/100 test(s) passed.
@@ -134,19 +135,19 @@ unit</code></pre>
 <p>Copy the contents of that file into <code>src/UnderscoreFFI.purs</code>, and reload PSCi with that module loaded:</p>
 <pre><code>&gt; import UnderscoreFFI</code></pre>
 <p>The <code>UnderscoreFFI</code> module defines a wrapper for the <code>sortBy</code> function. Let’s test that the function is idempotent:</p>
-<pre><code>&gt; let 
-    sortIsIdempotent :: [Int] -&gt; Boolean
+<pre><code>&gt; let
+    sortIsIdempotent :: Array Int -&gt; Boolean
     sortIsIdempotent arr = sortBy id (sortBy id arr) == sortBy id arr
-  
+
 &gt; quickCheck sortIsIdempotent
 
 100/100 test(s) passed.
 unit</code></pre>
 <p>In fact, we don’t need to sort by the identity function. Since QuickCheck supports higher-order functions, we can test with a randomly-generated sorting function:</p>
-<pre><code>&gt; let 
+<pre><code>&gt; let
     sortIsIdempotent' :: (Int -&gt; Int) -&gt; [Int] -&gt; Boolean
     sortIsIdempotent' f arr = sortBy f (sortBy f arr) == sortBy f arr
-  
+
 &gt; quickCheck sortIsIdempotent
 
 100/100 test(s) passed.

--- a/download/index.html
+++ b/download/index.html
@@ -29,15 +29,28 @@ brew install purescript
 
   <h2>Stack</h2>
 
-  <p><a href="https://www.haskell.org/ghc/">GHC</a> 7.10.1 or newer is required to compile from source. The easiest way is to use <a href="https://github.com/commercialhaskell/stack">Stack</a>:</p>
+  <p><a href="https://www.haskell.org/ghc/">GHC</a> 7.10.1 or newer is required to compile from source. The easiest way is to use <a href="https://github.com/commercialhaskell/stack">Stack</a>.</p>
+
+  <p>Update the Hackage package index:</p>
   <pre>
-stack install purescript --resolver=nightly
-</pre>
+stack update</pre>
+
+  <p>Download the latest source distribution and place it into a new directory in the current directory:</p>
+  <pre>
+stack unpack purescript</pre>
+
+  <p>Compile and install PureScript:</p>
+  <pre>
+cd purescript-x.y.z   # (replace x.y.z with whichever version you just downloaded)
+stack install</pre>
 
   <p>This will copy the compiler and utilities into <code>~/.local/bin</code>.</p>
 
   <p>If you don't have Stack installed, there are install instructions <a href="https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md">here</a>.</p>
 
+  <p>You can also install a specific version by specifying it in the <code>stack unpack</code> step. For example, to install 0.8.5, use:</p>
+  <pre>
+  stack unpack purescript-0.8.5</pre>
 </section>
 
 <section>


### PR DESCRIPTION
This has two main benefits over what we have currently:

It means that people end up using the same install plan that we use in
the binaries; currently, encouraging people to use nightly resolvers
will mean that they sometimes get new versions of libraries we depend
on, resulting in a set of dependencies which we haven't run the compiler
test suite with, or even used together.

It also means that people aren't limited to only those versions of
purescript which have made it into a nightly version. For example, when
we depend on some other package which isn't yet in the nightly snapshots
(for example, because not everything in the snapshot works with its
newer versions yet), that version of purescript would not be
installable. By contrast, this approach will work for any version of
PureScript which is on Hackage.