### PR TITLE
Remove old blogpost

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -111,7 +111,6 @@
     <li><a href="http://blog.functorial.com/posts/2015-11-20-Thermite.html">Building a Task List Application with Thermite</a> <small>(at <a href="http://blog.functorial.com">blog.functorial.com</a>)</small></li>
     <li><a href="http://www.parsonsmatt.org/programming/2015/10/22/purescript_router.html">Using purescript-routing with purescript-halogen</a> <small>(at <a href="http://parsonsmatt.org">parsonsmatt.org</a>)</small></li>
     <li><a href="http://www.parsonsmatt.org/programming/2015/10/05/elm_vs_purescript_ii.html">The Elm Architecture in PureScript</a> <small>(at <a href="http://parsonsmatt.org">parsonsmatt.org</a>)</small></li>
-    <li><a href="https://kritzcreek.github.io/tutorial/2015/10/07/playing-tic-tac-toe-with-purescript-signal/">Playing Tic-Tac-Toe using purescript-signal</a> <small>(at <a href="http://kritzcreek.github.io">kritzcreek.github.io</a>)</small></li>
   </ul>
 
   <div>Please contribute your own content by <a href="https://github.com/purescript/purescript.github.io">sending a pull request</a>.</div>


### PR DESCRIPTION
the blogpost doesn't work with the newest compiler. I've made a new blog today and will try to move the old blog posts over. Until then remove this dead link