### PR TITLE
Type signature in /learn/eff

### DIFF
--- a/learn/eff/index.markdown
+++ b/learn/eff/index.markdown
@@ -230,7 +230,7 @@ Note the type we give to `incrCounter`: we use a polymorphic type to make sure t
 Usually, we wouldn't write a handler for the `Counter` effect, since we have no way to guarantee that the `globalCounter` hasn't been modified. However, if we wanted to provide an unsafe "escape hatch" for `Counter`, we might do so as follows:
 
 ```purescript
-foreign import unsafeRunCounter :: forall e. Eff (counter :: COUNTER | e) a -> Eff e a
+foreign import unsafeRunCounter :: forall e a. Eff (counter :: COUNTER | e) a -> Eff e a
 ```
 
 And in JavaScript:


### PR DESCRIPTION
I just read the http://www.purescript.org/learn/eff/ documentation and came across this type signature:

```
foreign import unsafeRunCounter :: forall e. Eff (counter :: COUNTER | e) a -> Eff e a
```

I am new to purescript but if I understand it correctly the `a` type needs to be quantified as well.