### PR TITLE
Generator

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -45,7 +45,7 @@
       <h3>Examples</h3>
       <div class="current example">
         <h4>Modifying the DOM</h4>
-        <p>PureScript’s expressive type system and lightweight syntax make it simple to define <a href="https://leanpub.com/purescript/read#leanpub-auto-domain-specific-languages">domain-specific languages</a>, which can be used to solve problems like templating the DOM. Bindings also exist for libraries such as React and Angular.js.</p>
+        <p>PureScript’s expressive type system and lightweight syntax make it simple to define <a href="https://leanpub.com/purescript/read#leanpub-auto-domain-specific-languages">domain-specific languages</a>, which can be used to solve problems like templating the DOM. Bindings also exist for libraries such as React and Virtual DOM.</p>
 <pre>
 <span class="kr">import</span> <span class="nn">Flare</span>
 <span class="kr">import</span> <span class="nn">Flare.Smolder</span>
@@ -56,8 +56,8 @@
   <span class="nf">greet</span> name = h1 <span class="kt">$</span> text <span class="kt">$</span> <span class="s">"Hello, "</span> <span class="kt">&lt;&gt;</span> name <span class="kt">&lt;&gt;</span> <span class="s">"!"</span></pre>
       </div>
       <div class="example">
-	       <h4>HTML5 Canvas</h4>
-         <p>Higher-order functions allow the developer to write fluent, expressive code. Here, higher-order functions are being used to capture some common patterns when <a href="https://leanpub.com/purescript/read#leanpub-auto-canvas-graphics">working with HTML5 canvas</a>, such as closing and filling paths.</p>
+        <h4>HTML5 Canvas</h4>
+        <p>Higher-order functions allow the developer to write fluent, expressive code. Here, higher-order functions are being used to capture some common patterns when <a href="https://leanpub.com/purescript/read#leanpub-auto-canvas-graphics">working with HTML5 canvas</a>, such as closing and filling paths.</p>
 <pre>
 <span class="kr">import</span> <span class="nn">Control.Apply</span>
 <span class="kr">import</span> <span class="nn">Graphics.Canvas.Free</span>
@@ -83,7 +83,7 @@
 <span class="nf">loadModel</span> = <span class="kr">do</span>
   popular <- get <span class="s">"/products/popular"</span>
   products <- runPar $ for_ popular \product -> <span class="kt">Par</span> (get product.uri)
-  return $ <span class="kt">Model</span> products</pre>
+  pure (<span class="kt">Model</span> products)</pre>
       </div>
       <div class="example">
         <h4>Generative Testing</h4>

--- a/_site/learn/eff/index.html
+++ b/_site/learn/eff/index.html
@@ -82,8 +82,8 @@ bower install --save purescript-console purescript-random</code></pre>
 <h4 id="extensible-records-and-extensible-effects">Extensible Records and Extensible Effects</h4>
 <p>We can inspect the type of <code>printRandom</code> by using the <code>:type command</code></p>
 <pre><code>&gt; import RandomExample
-&gt; :type main</code></pre>
-<p>The type of <code>main</code> will be printed to the console. You should see a type which looks like this:</p>
+&gt; :type printRandom</code></pre>
+<p>The type of <code>printRandom</code> will be printed to the console. You should see a type which looks like this:</p>
 <pre><code>forall e. Eff (console :: CONSOLE, random :: RANDOM | e) Unit</code></pre>
 <p>This type looks quite complicated, but is easily explained by analogy with PureScript’s extensible records system.</p>
 <p>Consider a simple function which uses extensible records:</p>
@@ -150,7 +150,7 @@ divide n m <span class="fu">=</span> pure (n <span class="fu">/</span> m)</code>
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">import </span><span class="dt">Data.Either</span>
 
 <span class="ot">dividePure ::</span> <span class="dt">Int</span> <span class="ot">-&gt;</span> <span class="dt">Int</span> <span class="ot">-&gt;</span> <span class="dt">Either</span> <span class="dt">String</span> <span class="dt">Int</span>
-dividePure n m <span class="fu">=</span> runPure (catchException (return <span class="fu">&lt;&lt;&lt;</span> <span class="dt">Left</span>) (<span class="dt">Right</span> <span class="fu">&lt;$&gt;</span> divide n m))</code></pre></div>
+dividePure n m <span class="fu">=</span> runPure (catchException (pure <span class="fu">&lt;&lt;&lt;</span> <span class="dt">Left</span> <span class="fu">&lt;&lt;&lt;</span> message) (<span class="dt">Right</span> <span class="fu">&lt;$&gt;</span> divide n m))</code></pre></div>
 <p>Note that <em>after</em> we use <code>catchException</code> to remove the <code>EXCEPTION</code> effect, there are no more effects remaining, so we can use <code>runPure</code> to evaluate the return value.</p>
 <h4 id="defining-new-effect-types">Defining New Effect Types</h4>
 <p>New effects can be defined using <code>foreign import data</code> just as in the case of types.</p>
@@ -166,7 +166,7 @@ dividePure n m <span class="fu">=</span> runPure (catchException (return <span c
 <span class="op">};</span></code></pre></div>
 <p>Note the type we give to <code>incrCounter</code>: we use a polymorphic type to make sure that <code>Counter</code> can be interleaved with other effects.</p>
 <p>Usually, we wouldn’t write a handler for the <code>Counter</code> effect, since we have no way to guarantee that the <code>globalCounter</code> hasn’t been modified. However, if we wanted to provide an unsafe “escape hatch” for <code>Counter</code>, we might do so as follows:</p>
-<pre class="purescript"><code>foreign import unsafeRunCounter :: forall e. Eff (counter :: COUNTER | e) a -&gt; Eff e a</code></pre>
+<pre class="purescript"><code>foreign import unsafeRunCounter :: forall e a. Eff (counter :: COUNTER | e) a -&gt; Eff e a</code></pre>
 <p>And in JavaScript:</p>
 <div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="va">exports</span>.<span class="at">unsafeRunCounter</span> <span class="op">=</span> <span class="kw">function</span>(f) <span class="op">{</span>
   <span class="cf">return</span> f<span class="op">;</span>

--- a/_site/learn/index.html
+++ b/_site/learn/index.html
@@ -147,7 +147,6 @@
     <li><a href="http://blog.functorial.com/posts/2015-11-20-Thermite.html">Building a Task List Application with Thermite</a> <small>(at <a href="http://blog.functorial.com">blog.functorial.com</a>)</small></li>
     <li><a href="http://www.parsonsmatt.org/programming/2015/10/22/purescript_router.html">Using purescript-routing with purescript-halogen</a> <small>(at <a href="http://parsonsmatt.org">parsonsmatt.org</a>)</small></li>
     <li><a href="http://www.parsonsmatt.org/programming/2015/10/05/elm_vs_purescript_ii.html">The Elm Architecture in PureScript</a> <small>(at <a href="http://parsonsmatt.org">parsonsmatt.org</a>)</small></li>
-    <li><a href="https://kritzcreek.github.io/tutorial/2015/10/07/playing-tic-tac-toe-with-purescript-signal/">Playing Tic-Tac-Toe using purescript-signal</a> <small>(at <a href="http://kritzcreek.github.io">kritzcreek.github.io</a>)</small></li>
   </ul>
 
   <div>Please contribute your own content by <a href="https://github.com/purescript/purescript.github.io">sending a pull request</a>.</div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       <h3>Examples</h3>
       <div class="current example">
         <h4>Modifying the DOM</h4>
-        <p>PureScript’s expressive type system and lightweight syntax make it simple to define <a href="https://leanpub.com/purescript/read#leanpub-auto-domain-specific-languages">domain-specific languages</a>, which can be used to solve problems like templating the DOM. Bindings also exist for libraries such as React and Angular.js.</p>
+        <p>PureScript’s expressive type system and lightweight syntax make it simple to define <a href="https://leanpub.com/purescript/read#leanpub-auto-domain-specific-languages">domain-specific languages</a>, which can be used to solve problems like templating the DOM. Bindings also exist for libraries such as React and Virtual DOM.</p>
 <pre>
 <span class="kr">import</span> <span class="nn">Flare</span>
 <span class="kr">import</span> <span class="nn">Flare.Smolder</span>
@@ -20,8 +20,8 @@
   <span class="nf">greet</span> name = h1 <span class="kt">$</span> text <span class="kt">$</span> <span class="s">"Hello, "</span> <span class="kt">&lt;&gt;</span> name <span class="kt">&lt;&gt;</span> <span class="s">"!"</span></pre>
       </div>
       <div class="example">
-	       <h4>HTML5 Canvas</h4>
-         <p>Higher-order functions allow the developer to write fluent, expressive code. Here, higher-order functions are being used to capture some common patterns when <a href="https://leanpub.com/purescript/read#leanpub-auto-canvas-graphics">working with HTML5 canvas</a>, such as closing and filling paths.</p>
+        <h4>HTML5 Canvas</h4>
+        <p>Higher-order functions allow the developer to write fluent, expressive code. Here, higher-order functions are being used to capture some common patterns when <a href="https://leanpub.com/purescript/read#leanpub-auto-canvas-graphics">working with HTML5 canvas</a>, such as closing and filling paths.</p>
 <pre>
 <span class="kr">import</span> <span class="nn">Control.Apply</span>
 <span class="kr">import</span> <span class="nn">Graphics.Canvas.Free</span>
@@ -47,7 +47,7 @@
 <span class="nf">loadModel</span> = <span class="kr">do</span>
   popular <- get <span class="s">"/products/popular"</span>
   products <- runPar $ for_ popular \product -> <span class="kt">Par</span> (get product.uri)
-  return $ <span class="kt">Model</span> products</pre>
+  pure (<span class="kt">Model</span> products)</pre>
       </div>
       <div class="example">
         <h4>Generative Testing</h4>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "purescript-site",
   "private": true,
   "scripts": {
-    "sass": "echo try{require('fs').mkdirSync('css');}catch(e){}; require('fs').writeFileSync('css/style.css', require('node-sass').renderSync({ file: 'sass/style.scss', outputStyle: 'compressed' }).css); | node",
+    "sass": "echo \"try{require('fs').mkdirSync('css');}catch(e){}; require('fs').writeFileSync('css/style.css', require('node-sass').renderSync({ file: 'sass/style.scss', outputStyle: 'compressed' }).css);\" | node",
     "rebuild": "npm run sass && stack --stack-yaml stack.yaml exec site rebuild"
   },
   "dependencies": {


### PR DESCRIPTION
fix sass script

return -> pure in Aff example

swap reference to Angular with Virtual DOM (I'm fine with not listing Virtual DOM I just want Angular to be dropped).