### PR TITLE
Fixed syntax

### DIFF
--- a/_generator/index.html
+++ b/_generator/index.html
@@ -28,8 +28,8 @@
           You can <a href="http://try.purescript.org/?gist=1c497b0533c1e1e4c21ebdbbd4195a79&backend=flare">try this example</a> online.
         </p>
 <pre>
-<span class="kr">import</span> <span class="nn">import Flare</span>
-<span class="kr">import</span> <span class="nn">import Flare.Drawing</span>
+<span class="kr">import</span> <span class="nn">Flare</span>
+<span class="kr">import</span> <span class="nn">Flare.Drawing</span>
 
 <span class="nf">thrice</span> f x = f (f (f x))
 


### PR DESCRIPTION
Removed two imports for importing Flare and importing Flare.Drawing, but in _generator this time.