### PR TITLE
Update required Node version

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
 
           <h3>npm</h3>
           <p><code>npm install -g purescript</code></p>
-          <p><small>(Installation via <code>npm</code> requires Node version 6 or later)</small></p>
+          <p><small>(Installation via <code>npm</code> requires Node version 8 or later)</small></p>
 
           <h3>Tools</h3>
           <p>The recommended build tool for beginners is Pulp, which can be installed using <code>npm</code>:</p>


### PR DESCRIPTION
Node 6.x doesn't support object spread syntax, which is used in one of the dependencies of the npm package.