### PR TITLE
Add links to Discord and Zulip chat instances

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,9 +213,11 @@
           <h3>Community</h3>
           <p>There are several places in which people gather to discuss PureScript:</p>
           <ul style="padding-left: 15px">
-            <li><strong>Slack</strong> - The #purescript channel on <a href="https://functionalprogramming.slack.com/">FP Slack</a>. Use the <a href="https://fpchat-invite.herokuapp.com/">FP Slack invite bot</a> to make an account there.</li>
+            <li><strong>Slack</strong> - The #purescript and #purescript-beginners channels on <a href="https://functionalprogramming.slack.com/">FP Slack</a>. Use the <a href="https://fpchat-invite.herokuapp.com/">FP Slack invite bot</a> to make an account there.</li>
             <li><strong>IRC</strong> - The <a href="irc://irc.freenode.net/purescript">#purescript channel on Freenode</a>.</li>
             <li><strong>Discourse</strong> - The <a href="https://discourse.purescript.org">PureScript Discourse</a> instance.</li>
+            <li><strong>Discord</strong> - The <a href="https://discordapp.com/invite/55xWDSq">#purescript</a> channel on FP Discord</li>
+            <li><strong>Zulip</strong> - The <a href="https://funprog.zulipchat.com/#narrow/stream/214955-PureScript">#purescript</a> and <a href="https://funprog.zulipchat.com/#narrow/stream/215392-PureScript-beginners">#purescript-beginners</a> channels on FP Zulip.</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Currently using @thomashoneyman's Discord invite link. I couldn't figure out how to link to the channel without it being through user invite.