### PR TITLE
Remove mention of freenode IRC channel

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,6 @@
           <p>There are several places in which people gather to discuss PureScript:</p>
           <ul style="padding-left: 15px">
             <li><strong>Slack</strong> - The #purescript channel on <a href="https://functionalprogramming.slack.com/">FP Slack</a>. Use the <a href="https://fpchat-invite.herokuapp.com/">FP Slack invite bot</a> to make an account there.</li>
-            <li><strong>IRC</strong> - The <a href="irc://irc.freenode.net/purescript">#purescript channel on Freenode</a>.</li>
             <li><strong>Discourse</strong> - The <a href="https://discourse.purescript.org">PureScript Discourse</a> instance.</li>
           </ul>
         </div>
@@ -229,8 +228,7 @@
       <a href="https://twitter.com/purescript"><i class="fa fa-twitter-square"></i></a>
     </p>
     <p class="text-center text-muted"><small>&copy; PureScript 2017–2020</small></p>
-    <p class="text-center text-muted"><small>The PureScript logo by Gareth Hughes is used under the terms of the Creative Commons Attribution 4.0 license.
-</small></p>
+    <p class="text-center text-muted"><small>The PureScript logo by Gareth Hughes is used under the terms of the Creative Commons Attribution 4.0 license.</small></p>
   </footer>
 
 </body>


### PR DESCRIPTION
With the changes at freenode, seems like a good idea to remove the mentions of the channel from the website.