### PR TITLE
Update community link from Slack to Discord

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,8 +215,8 @@
           <h3>Community</h3>
           <p>There are several places in which people gather to discuss PureScript:</p>
           <ul style="padding-left: 15px">
-            <li><strong>Slack</strong> - The #purescript channel on <a href="https://functionalprogramming.slack.com/">FP Slack</a>. Use the <a href="https://fpchat-invite.herokuapp.com/">FP Slack invite bot</a> to make an account there.</li>
             <li><strong>Discourse</strong> - The <a href="https://discourse.purescript.org">PureScript Discourse</a> instance.</li>
+            <li><strong>Discord</strong> - The <a href="https://discord.gg/sMqwYUbvz6">Purescript Discord</a> server.</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
This PR updates the link to the FP Slack to instead point to our PureScript Discord server. I've not included separate text about getting an invite vs. going to the server because the permanent invite link I've included will already either  a) allow the user to join the server or b) will take them directly to the server if they're already a member. 

We shouldn't deploy a new version of the site until July 26 when we're ready to migrate to Discord.