### PR TITLE
Add a redirect for Discord

### DIFF
--- a/discord/index.html
+++ b/discord/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Discord</title>
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://discord.com/invite/RXcbGQGEHj"
+    />
+  </head>
+  <body>
+    <h1>PureScript Discord</h1>
+    <p>
+      Redirecting you to the
+      <a href="https://discord.com/invite/RXcbGQGEHj">PureScript Discord</a>...
+    </p>
+  </body>
+</html>

--- a/discord/index.html
+++ b/discord/index.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Discord</title>
+    <title>Chat</title>
     <meta
       http-equiv="refresh"
       content="0; url=https://discord.com/invite/RXcbGQGEHj"
     />
   </head>
   <body>
-    <h1>PureScript Discord</h1>
+    <h1>PureScript Chat</h1>
     <p>
       Redirecting you to the
-      <a href="https://discord.com/invite/RXcbGQGEHj">PureScript Discord</a>...
+      <a href="https://discord.com/invite/RXcbGQGEHj">PureScript Chat</a>...
     </p>
   </body>
 </html>


### PR DESCRIPTION
This PR introduces a HTML redirect for Discord, so that we can link to `purescript.org/discord` in documentation and have them get a usable invite link instead of to the link itself. This is an improvement because it means we can change the invite link going forward. Some examples of how that could happen:

* The server owner leaves, which will cause their permanent invite link to expire
* We change the default channel we invite people to

Once merged and tested, I intend to update our links to the old invite link to point to this instead.